### PR TITLE
authTypes

### DIFF
--- a/frontend/src/Components/auth/constants.tsx
+++ b/frontend/src/Components/auth/constants.tsx
@@ -20,7 +20,7 @@ export const auth_constants = {
     },
     verifyEmail: {
         success: 'Email address verified successfully',
-        four04: 'Email address not found',
+        notFound: 'Email address not found',
         title: "Verify Email",
         email: "Email",
     },

--- a/frontend/src/Components/auth/types.ts
+++ b/frontend/src/Components/auth/types.ts
@@ -15,9 +15,7 @@ export interface SignUpFormValues {
     message: string;
   }
   
-  export interface SignUpProps {
-    // Add any props specific to SignUp component here
-  }
+  export type SignUpProps = Record<string, unknown>;
 
   //Login
   export interface LoginFormValues {

--- a/frontend/src/Components/auth/types.ts
+++ b/frontend/src/Components/auth/types.ts
@@ -39,6 +39,4 @@ export interface VerifyEmailMessages {
     success?: string;
     four04?: string;
   }
-  export interface VerifyEmailProps {
-    // Add any props specific to VerifyEmail component here
-  }
+  export type VerifyEmailProps = Record<string, unknown>;

--- a/frontend/src/Components/auth/types.ts
+++ b/frontend/src/Components/auth/types.ts
@@ -34,9 +34,7 @@ export interface SignUpFormValues {
     message: string;
   }
   
-  export interface LoginProps {
-    // Add any props specific to Login component here
-  }
+  export type LoginProps = Record<string, unknown>;
 
   //Verify Email
 export interface VerifyEmailMessages {


### PR DESCRIPTION
## Pull request summary created by Squire AI

### Summary
This pull request focuses on updating type definitions and constants related to authentication. Specifically, it renames the 'four04' key to 'notFound' in the verifyEmail object within constants.tsx for better clarity. Additionally, it replaces the SignUpProps, LoginProps, and VerifyEmailProps interfaces with a more flexible Record<string, unknown> type in types.ts to simplify type management.

82b96447754b6b7c82d237e4bc0a6a502938563c...042e77b7b9c720f05335bec7f78427d9bedf3082

### File Summary
#### File Changes
* `constants.tsx`: Renamed 'four04' key to 'notFound' in verifyEmail object.
* `types.ts`: Replaced SignUpProps, LoginProps, and VerifyEmailProps interfaces with Record<string, unknown> type.

82b96447754b6b7c82d237e4bc0a6a502938563c...042e77b7b9c720f05335bec7f78427d9bedf3082